### PR TITLE
fix delay-detector mismatch

### DIFF
--- a/format_json.py
+++ b/format_json.py
@@ -11,13 +11,13 @@ base_message = { "False Alarm Prob": "13.96%",
      "sub list number": 0}
 
 
-def get_json_data(date_string, detectors_selected, delay_df):
+def get_json_data(date_string, delay_df):
     message = base_message.copy()
     message['_id'] = f"SNEWS_Coincidence_ALERT-UPDATE {date_string}"
     # date_stripped = ".".join(date_string.strip('.')[:-1])[:-1]
     message["neutrino_times"] = list(delay_df['times'])
     message["sent_time"] = date_string
-    message["detector_names"] = list(detectors_selected.index)
+    message["detector_names"] = list(delay_df.index)
     data_string = json.dumps(message)
     href = f"data:text/json;charset=utf-8,{data_string}"
     return href
@@ -32,9 +32,9 @@ base_detector_msg = {
         "this is a test"
 }
 
-def get_json_per_detector(date_string, detectors_selected, delay_df):
+def get_json_per_detector(delay_df):
     master_dict = {}
-    for detector, delay in zip(detectors_selected.index, delay_df['times']):
+    for detector, delay in zip(delay_df.index, delay_df['times']):
         message = base_detector_msg.copy()
         message["neutrino_time"] = delay
         message["detector_name"] = detector

--- a/sn_nu_delays.py
+++ b/sn_nu_delays.py
@@ -357,8 +357,8 @@ def update_positions(obstime, selected_detectors, candid_selected):
     star_xyz = star_pos.loc[candid_name, ['x (m)', 'y (m)', 'z (m)']]
     delay_df = delays_for_time_star(star_xyz, detectors_selected, obstime_str=date_string)
 
-    href = get_json_data(date_string, detectors_selected, delay_df)
-    href_detectors = get_json_per_detector(date_string, detectors_selected, delay_df)
+    href = get_json_data(date_string, delay_df)
+    href_detectors = get_json_per_detector(delay_df)
     return fig, generate_table(delay_df), href, href_detectors
 
 


### PR DESCRIPTION
fixed the mismatch between detector names and delay
This was caused by passing two df's to formatting function and once the detectors changed, the order was being messed